### PR TITLE
Update dependencies

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -184,7 +184,7 @@ class TestLabradTypes:
             (ValueArray([1.0, 2], ''), np.array([1.0, 2]),
                 np.testing.assert_array_almost_equal),
             # Numpy scalar types
-            (np.bool8(True), True, None) 
+            (np.bool8(True) if hasattr(np, 'bool8') else np.bool_(True), True, None)
         ]
         for input, expected, comparison_func in tests:
             unflat = T.unflatten(*T.flatten(input))

--- a/labrad/types/types.py
+++ b/labrad/types/types.py
@@ -598,12 +598,13 @@ class TBool(Type, Singleton):
         return bool(ord(s.get(1)))
 
     def __flatten__(self, b, endianness):
-        if not isinstance(b, (bool, np.bool8)):
+        numpy_bool = np.bool8 if hasattr(np, 'bool8') else np.bool_
+        if not isinstance(b, (bool, numpy_bool)):
             raise FlatteningError(b, self)
         return b'\x01' if b else b'\x00', self
 
 registerType(bool, TBool())
-registerType(np.bool8, TBool())
+registerType(np.bool8 if hasattr(np, 'bool8') else np.bool_, TBool())
 
 class TInt(Type, Singleton):
     """A signed 32-bit integer."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-numpy >= 1.12; python_version < '3.7'
-numpy >= 1.15; python_version == '3.7'
-numpy >= 1.17; python_version >= '3.8'
-pyOpenSSL >= 18.0
-pyparsing >= 2.1
-requests
-service_identity
-twisted >= 18.4
+numpy >= 2.2
+pyOpenSSL >= 25.1.0
+pyparsing >= 3.2.3
+requests >= 2.32.3
+service_identity >= 24.2.0
+twisted >= 24.11.0


### PR DESCRIPTION
## Summary
- bump dependencies to the newest releases
- adapt numpy bool usage for numpy 2
- update a numpy-specific test

## Testing
- `pytest -q` *(fails: twisted.internet.error.ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_683f6bdc17e88326aa6ee9260396d83e