### PR TITLE
Ensure Java 17 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For help getting started and understanding pylabrad take a look at the [wiki](ht
 As of version 0.96.0, pylabrad is no longer compatible with the Delphi labrad manager available from Sourceforge.
 Instead, use the new [scalabrad manager](https://github.com/labrad/scalabrad).
 The user interface for the manager and node along with the registry editor and grapher is now [web-based (scalabrad-web)](https://github.com/labrad/scalabrad-web).
+The manager (version 0.9.0 and later) requires **Java 17** or newer. Ensure a compatible JRE is available on your `PATH` before running the manager or executing the test suite.
 
 ## Node Server
 

--- a/labrad/node/node_test.py
+++ b/labrad/node/node_test.py
@@ -110,7 +110,7 @@ def clear_queue(q):
 class TestNode(object):
 
     def test_node_autodetect(self):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             with run_node('test', cxn) as n:
                 servers = n.node.available_servers()
                 assert 'Python Test Server' in servers
@@ -132,7 +132,7 @@ class TestNode(object):
                 assert 'Local Python Test Server' in servers
 
     def test_node_status_on_startup(self):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             with subscribe_to_node_messages(cxn) as mq:
                 with run_node('test', cxn, update_registry=False) as n:
                     self._check_status_message(mq.get(timeout=1))
@@ -169,7 +169,7 @@ class TestNode(object):
                     remaining_names.remove(message_name)
                     assert dict(message_params) == expected_message
 
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             with run_node(node_name, cxn) as n:
                 with subscribe_to_node_messages(cxn) as mq:
                     n.node.start(name)
@@ -229,7 +229,7 @@ class TestNode(object):
         )
 
     def test_node_shuts_down_running_servers_when_stopped(self):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             with run_node('test', cxn) as n:
                 n.node.start('Python Test Server')
                 n.node.start('Local Python Test Server')
@@ -253,7 +253,7 @@ class TestNode(object):
             message = 987654321
             timeout = 5
         """
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             with run_node('test', cxn) as n:
                 with util.temp_directory() as temp_dir:
                     # start running an existing server version

--- a/labrad/test/test_client.py
+++ b/labrad/test/test_client.py
@@ -13,7 +13,7 @@ class TestClient:
     def setup_class(cls):
         cls.exit_stack = contextlib.ExitStack()
         cls.exit_stack.enter_context(syncRunServer(PythonTestServer()))
-        cls.cxn = cls.exit_stack.enter_context(labrad.connect())
+        cls.cxn = cls.exit_stack.enter_context(labrad.connect(timeout=5))
 
     def teardown_class(cls):
         cls.exit_stack.close()

--- a/labrad/test/test_refresh.py
+++ b/labrad/test/test_refresh.py
@@ -44,7 +44,7 @@ class RefreshServer3(LabradServer):
         pass
 
 def test_refresh():
-    with labrad.connect() as cxn:
+    with labrad.connect(timeout=5) as cxn:
 
         assert not hasattr(cxn, 'refresh_test_server')
 

--- a/labrad/test/test_server.py
+++ b/labrad/test/test_server.py
@@ -23,7 +23,7 @@ def test_server_expire_context_method_is_called():
             return data
 
     with util.syncRunServer(TestServer()):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             # create a random context owned by this connection
             request_context = (cxn.ID, random.randint(0, 2**32-1))
             cxn.testserver.echo('hello, world!', context=request_context)
@@ -41,7 +41,7 @@ def test_threaded_server_client_can_be_spawned():
                 return cxn[server][setting](data)
 
     with util.syncRunServer(TestServer()):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             result = cxn.testserver.spawn_call('Manager', 'Echo', 'woot!')
             assert result == 'woot!'
 

--- a/labrad/test/test_signal.py
+++ b/labrad/test/test_signal.py
@@ -27,7 +27,7 @@ class SignalTestServer(LabradServer):
 
 def _test_signals(signal_setting, fire_setting):
     with labrad.util.syncRunServer(SignalTestServer()):
-        with labrad.connect() as cxn:
+        with labrad.connect(timeout=5) as cxn:
             server = cxn.signal_test_server
             msg_id = 12345
 

--- a/labrad/test/test_tls.py
+++ b/labrad/test/test_tls.py
@@ -128,8 +128,7 @@ def run_manager(tls_required, port=None, tls_port=None, startup_timeout=20):
             start = time.time()
             while True:
                 try:
-                    labrad.connect(port=tls_port, tls_mode='on',
-                                   password=password)
+                    labrad.connect(port=tls_port, tls_mode='on', password=password, timeout=5)
                 except Exception as e:
                     last_error = e
                 else:
@@ -153,22 +152,19 @@ def run_manager(tls_required, port=None, tls_port=None, startup_timeout=20):
 
 def test_connect_with_starttls():
     with run_manager(tls_required=True) as m:
-        with labrad.connect(port=m.port, tls_mode='starttls-force',
-                            password=m.password) as cxn:
+        with labrad.connect(port=m.port, tls_mode='starttls-force', password=m.password, timeout=5) as cxn:
             pass
 
 
 def test_connect_with_optional_starttls():
     with run_manager(tls_required=False) as m:
-        with labrad.connect(port=m.port, tls_mode='off',
-                            password=m.password) as cxn:
+        with labrad.connect(port=m.port, tls_mode='off', password=m.password, timeout=5) as cxn:
             pass
 
 
 def test_connect_with_tls():
     with run_manager(tls_required=True) as m:
-        with labrad.connect(port=m.tls_port, tls_mode='on',
-                            password=m.password) as cxn:
+        with labrad.connect(port=m.tls_port, tls_mode='on', password=m.password, timeout=5) as cxn:
             pass
 
 
@@ -178,24 +174,21 @@ def test_connect_with_tls():
 def test_expect_starttls_use_off():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.port, tls_mode='off',
-                                password=m.password) as cxn:
+            with labrad.connect(port=m.port, tls_mode='off', password=m.password, timeout=5) as cxn:
                 pass
 
 
 def test_expect_tls_use_off():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.tls_port, tls_mode='off',
-                                password=m.password) as cxn:
+            with labrad.connect(port=m.tls_port, tls_mode='off', password=m.password, timeout=5) as cxn:
                 pass
 
 
 def test_expect_tls_use_starttls():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.tls_port, tls_mode='off',
-                                password=m.password) as cxn:
+            with labrad.connect(port=m.tls_port, tls_mode='off', password=m.password, timeout=5) as cxn:
                 pass
 
 

--- a/scripts/test/test.sh
+++ b/scripts/test/test.sh
@@ -1,8 +1,32 @@
 #!/bin/sh
 
+set -e
+
+# Ensure Java 17+ is available
+JAVA_STR=$(java -version 2>&1 | awk -F\" '/version/ {print $2}')
+JAVA_MAJOR=$(echo $JAVA_STR | cut -d. -f1)
+if [ "$JAVA_MAJOR" = "1" ]; then
+  JAVA_MAJOR=$(echo $JAVA_STR | cut -d. -f2)
+fi
+if [ "$JAVA_MAJOR" -lt 17 ]; then
+  echo "Java 17 or newer required; found $JAVA_STR" >&2
+  exit 1
+fi
+
 export LABRADHOST=localhost
 export LABRADPASSWORD=testpass
-export LABRADPORT=7777
+# Pick free ports for manager so tests do not clash with other services
+get_free_port() {
+  python3 - <<'EOF'
+import socket
+s=socket.socket()
+s.bind(('',0))
+print(s.getsockname()[1])
+s.close()
+EOF
+}
+export LABRADPORT="$(get_free_port)"
+export LABRAD_TLS_PORT="$(get_free_port)"
 export CI=true
 
 # Ensure scalabrad is installed and available
@@ -32,7 +56,7 @@ fi
 python3 -m pip install --break-system-packages --no-deps .
 
 # start labrad manager
-labrad 1>.labrad.log 2>.labrad.err.log &
+labrad --port=$LABRADPORT --tls-port=$LABRAD_TLS_PORT 1>.labrad.log 2>.labrad.err.log &
 LABRAD_PID=$!
 trap 'kill $LABRAD_PID 2>/dev/null' EXIT
 sleep 20


### PR DESCRIPTION
## Summary
- document Java 17 requirement for scalabrad
- validate Java version in test script before running tests
- pick free ports for manager to avoid conflicts in CI

## Testing
- `bash scripts/test/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68400b3967e88326bf86f86f671a6166